### PR TITLE
Multithreaded ray tracer now uses Atomic updates

### DIFF
--- a/src/Materials/Black.jl
+++ b/src/Materials/Black.jl
@@ -6,7 +6,7 @@
 all the power associated to the ray
 =#
 struct Black{nw} <: Material
-    power::MVector{nw, Float64} #::SArray{Tuple{nw},Threads.Atomic{Float64},1,nw}
+    power::SArray{Tuple{nw}, Threads.Atomic{Float64}, 1, nw}
 end
 
 """
@@ -22,7 +22,8 @@ julia> b = Black(1);
 julia> b = Black(3);
 ```
 """
-Black(nw::Int = 1) = Black(MVector{nw, Float64}(0.0 for _ in 1:nw))
+Black(nw::Int = 1) = Black(SArray{Tuple{nw}, Atomic{Float64}, 1, nw}(Atomic{Float64}(0)
+                                                                     for _ in 1:nw))
 
 ###############################################################################
 ################################## API ########################################
@@ -39,7 +40,9 @@ end
     Add all the power to the material and set power to 0
 =#
 function absorb_power!(material::Black, power, interaction)
-    material.power .+= power
+    @inbounds for i in eachindex(power)
+        atomic_add!(material.power[i], power[i])
+    end
     power .= 0.0
     return nothing
 end

--- a/src/Materials/Material.jl
+++ b/src/Materials/Material.jl
@@ -26,7 +26,7 @@ Reset the power stored inside a material back to zero
 ```jldoctest
 julia> l = Lambertian(τ = 0.1, ρ = 0.2);
 
-julia> l.power[1] = 10.0;
+julia> l.power[1].value = 10.0;
 
 julia> reset!(l);
 
@@ -35,7 +35,7 @@ julia> l;
 """
 function reset!(material::Material)
     for i in eachindex(material.power)
-        @inbounds material.power[i] = 0.0#.value = 0.0
+        @inbounds material.power[i].value = 0.0
     end
     return nothing
 end
@@ -57,4 +57,8 @@ julia> l = Lambertian(τ = 0.1, ρ = 0.2);
 julia> power(l);
 ```
 """
-power(material::Material) = material.power
+function power(mat::Material)
+    @inbounds nw = typeof(mat).parameters[1]
+    @inbounds typ = eltype(mat.power.data).parameters[1]
+    SVector{nw, typ}(pow.value for pow in mat.power)
+end

--- a/src/Materials/Sensor.jl
+++ b/src/Materials/Sensor.jl
@@ -6,7 +6,7 @@
 all the power associated to the ray
 =#
 struct Sensor{nw} <: Material
-    power::MVector{nw, Float64} #::SArray{Tuple{nw},Threads.Atomic{Float64},1,nw}
+    power::SArray{Tuple{nw}, Atomic{Float64}, 1, nw}
 end
 
 """
@@ -23,7 +23,9 @@ julia> s = Sensor(1);
 julia> s = Sensor(3);
 ```
 """
-Sensor(nw::Int = 1) = Sensor(MVector{nw, Float64}(0.0 for _ in 1:nw)) #Sensor(SArray{Tuple{nw},Threads.Atomic{Float64},1,nw}(Threads.Atomic{Float64}(0.0) for i in 1:nw))
+Sensor(nw::Int = 1) = Sensor(SArray{Tuple{nw}, Threads.Atomic{Float64}, 1, nw}(Threads.Atomic{
+    Float64,
+}(0.0) for i in 1:nw))
 
 ###############################################################################
 ################################## API ########################################
@@ -40,9 +42,9 @@ end
 #=
     Add all the power to the material but do not affect the power of the ray
 =#
-@inbounds function absorb_power!(material::Sensor, power, interaction)
-    for i in eachindex(power)
-        material.power[i] += power[i] #Threads.atomic_add!(material.power[i], power[i])
+function absorb_power!(material::Sensor, power, interaction)
+    @inbounds for i in eachindex(power)
+        atomic_add!(material.power[i], power[i])
     end
     return nothing
 end

--- a/src/PlantRayTracer.jl
+++ b/src/PlantRayTracer.jl
@@ -5,7 +5,7 @@ using LinearAlgebra
 import Statistics: quantile, mean
 import Base: intersect, length
 import Random
-import Base.Threads: @threads, nthreads
+import Base.Threads: @threads, nthreads, Atomic, atomic_add!
 
 # External dependencies
 import StaticArrays: SVector,

--- a/src/RayTracer/RayTracer.jl
+++ b/src/RayTracer/RayTracer.jl
@@ -232,7 +232,7 @@ function trace!(rt::RayTracer)
     # Run ray tracer across multiple threads
     if rt.settings.parallel
         # Each thread gets a deep copy of materials to avoid data races
-        materials = [deepcopy(rt.materials) for _ in 1:nthreads()]
+        #materials = [deepcopy(rt.materials) for _ in 1:nthreads()]
         # Each thread gets a different pseudo-random number generator which seed depends on the original one
         samplers = [deepcopy(rt.settings.sampler) for _ in 1:Threads.nthreads()]
         for i in 1:Threads.nthreads()
@@ -247,7 +247,8 @@ function trace!(rt::RayTracer)
         nrays_thread = zeros(Int, nthreads())
         @threads for i in 1:nthreads()
             @inbounds nrays_thread[i] = trace_thread!(rt,
-                materials[i],
+                rt.materials,
+                #materials[i],
                 nrays,
                 irays[i],
                 erays[i],
@@ -255,11 +256,11 @@ function trace!(rt::RayTracer)
         end
         nrays_traced = sum(nrays_thread)
         # Copy the power stored in each material back to the original
-        for it in 1:nthreads()
-            for im in 1:length(rt.materials)
-                @inbounds rt.materials[im].power .+= materials[it][im].power
-            end
-        end
+        # for it in 1:nthreads()
+        #     for im in 1:length(rt.materials)
+        #         @inbounds rt.materials[im].power .+= materials[it][im].power
+        #     end
+        # end
         # Run ray tracer in a single multiple thread
     else
         nrays_traced = trace_thread!(rt,

--- a/test/elements_raytracer.jl
+++ b/test/elements_raytracer.jl
@@ -291,9 +291,9 @@ let
     mode, coef = RT.choose_outcome(mat, source_power, rng)
     @test coef == [0.3]
     @test mode == :ρ
-    power(mat)[1] = 8.0
+    mat.power[1].value = 8.0
     RT.reset!(mat)
-    @test power(mat)[1] == 0.0
+    @test all(power(mat) .== [0.0])
 
     mat = RT.Lambertian(τ = 0.3, ρ = 0.0)
     @test mat isa RT.Material
@@ -319,8 +319,8 @@ let
     mode, coef = RT.choose_outcome(mat, source_power, rng)
     @test coef == [0.3, 0.3]
     @test mode == :ρ
-    power(mat)[1] = 8.0
-    power(mat)[2] = 2.0
+    mat.power[1].value = 8.0
+    mat.power[2].value = 2.0
     RT.reset!(mat)
     @test all(power(mat) .== zeros(2))
 
@@ -348,13 +348,13 @@ let
 
     # Black material
     mat = RT.Black(1)
-    @test all(power(mat) .== zeros(1))
+    @test all(power(mat) .== 0.0)
     mat = RT.Black(3)
     @test all(power(mat) .== zeros(3))
 
     # Sensor material
     mat = RT.Sensor(1)
-    @test all(power(mat) .== zeros(1))
+    @test all(power(mat) .== 0.0)
     mat = RT.Sensor(3)
     @test all(power(mat) .== zeros(3))
 end

--- a/test/raytracer.jl
+++ b/test/raytracer.jl
@@ -91,7 +91,7 @@ let
     nrays = trace!(rtobj)
 
     @test nrays == nrays
-    pow_abs = material[1].power[1]
+    pow_abs = material[1].power[1].value
     pow_gen = source.power[1] * source.nrays
     @test pow_abs ≈ pow_gen
 
@@ -113,7 +113,7 @@ let
     rtobj = RayTracer(scene, source, settings = settings, acceleration = Naive)
     nrays_traced = trace!(rtobj)
     @test nrays_traced == nrays
-    pow_abs = material[1].power[1]
+    pow_abs = material[1].power[1].value
     pow_gen = source.power[1] * source.nrays
     @test pow_abs ≈ pow_gen
 
@@ -135,7 +135,7 @@ let
     rtobj = RayTracer(scene, source, settings = settings, acceleration = Naive)
     nrays_traced = trace!(rtobj)
     @test nrays_traced == nrays
-    pow_abs = material[1].power[1]
+    pow_abs = material[1].power[1].value
     pow_gen = source.power[1] * source.nrays
     @test pow_abs == 0.0
 
@@ -157,7 +157,7 @@ let
     rtobj = RayTracer(scene, [source], settings = settings, acceleration = Naive)
     nrays_traced = trace!(rtobj)
     @test nrays_traced == nrays
-    pow_abs = material[1].power[1]
+    pow_abs = material[1].power[1].value
     pow_gen = source.power[1] * source.nrays
     @test pow_abs ≈ pow_gen
     @test pow_abs / area(rect) ≈ radiosity
@@ -191,7 +191,7 @@ let
     rtobj = RayTracer(scene, source, settings = settings, acceleration = Naive)
     nrays_traced = trace!(rtobj)
     @test nrays_traced == 3 * nrays
-    pow_abs = [material.power[1] for material in mats]
+    pow_abs = [material.power[1].value for material in mats]
     pow_gen = source.power[1] * source.nrays
     @test all(pow_abs .≈ pow_gen)
     @test all(pow_abs ./ area(rect1) .≈ radiosity)
@@ -211,7 +211,7 @@ let
     nrays_traced = trace!(rtobj)
 
     @test nrays_traced == 3 * nrays
-    pow_abs = [material.power[1] for material in mats]
+    pow_abs = [material.power[1].value for material in mats]
     pow_gen = source.power[1] * source.nrays
     @test all(pow_abs .≈ pow_gen)
     @test all(pow_abs ./ area(rect1) .≈ radiosity)
@@ -245,7 +245,7 @@ let
     nrays_traced = trace!(rtobj)
 
     @test nrays_traced > nrays
-    pow_abs = [material.power[1] for material in mats]
+    pow_abs = [material.power[1].value for material in mats]
     pow_gen = source.power[1] * source.nrays
     @test sum(pow_abs) < pow_gen
     @test pow_abs[1] < pow_abs[2] < pow_abs[3]
@@ -261,7 +261,7 @@ let
     nrays_traced = trace!(rtobj)
 
     @test nrays_traced > nrays
-    RTirrs = [mats[i].power[1] / area(rect1) for i in 1:3]
+    RTirrs = [mats[i].power[1].value / area(rect1) for i in 1:3]
     @test all(RTirrs .< [1.0 for i in 1:3])
     @test RTirrs[1] < RTirrs[2] < RTirrs[3]
     RTirrs_naive = deepcopy(RTirrs) # for comparison with BVH later
@@ -288,7 +288,7 @@ let
     nrays = trace!(rtobj)
 
     @test nrays == nrays
-    RTirr = mat[1].power[1] ./ area(rect)
+    RTirr = mat[1].power[1].value ./ area(rect)
     @test RTirr ≈ radiosity
 
     # render(rect)
@@ -315,7 +315,7 @@ let
         rule = SAH{1}(2, 5))
     nrays_traced = trace!(rtobj)
     @test nrays_traced == nrays
-    RTirr = mat[1].power[1] / area(rect)
+    RTirr = mat[1].power[1].value / area(rect)
     @test RTirr ≈ radiosity
 
     # Intersection of a rectangle from a directional light source downwards (sensor)
@@ -341,7 +341,7 @@ let
         rule = SAH{1}(2, 5))
     nrays_traced = trace!(rtobj)
     @test nrays_traced == 3nrays
-    RTirrs = [mats[i].power[1] / area(rect1) for i in 1:3]
+    RTirrs = [mats[i].power[1].value / area(rect1) for i in 1:3]
     @test RTirrs ≈ [1.0 for i in 1:3]
 
     # Intersection of a rectangle from a directional light source at an angle (sensor)
@@ -352,7 +352,7 @@ let
     nrays_traced = trace!(rtobj)
 
     @test nrays_traced == 3nrays
-    RTirrs = [mats[i].power[1] / area(rect1) for i in 1:3]
+    RTirrs = [mats[i].power[1].value / area(rect1) for i in 1:3]
     @test RTirrs ≈ [1.0 for i in 1:3]
 
     # Intersection of a rectangle from a directional light source at an angle (Lambertian)
@@ -382,7 +382,7 @@ let
     nrays_traced = trace!(rtobj)
 
     @test nrays_traced > nrays
-    RTirrs = [mats[i].power[1] / area(rect1) for i in 1:3]
+    RTirrs = [mats[i].power[1].value / area(rect1) for i in 1:3]
     @test all(RTirrs .< [1.0 for i in 1:3])
     @test RTirrs[1] < RTirrs[2] < RTirrs[3]
 
@@ -425,7 +425,7 @@ let
     function getpower(tree, query)
         powers = Float64[]
         for x in apply(tree, query)
-            push!(powers, x.mat.power[1])
+            push!(powers, x.mat.power[1].value)
         end
         return powers
     end
@@ -478,8 +478,8 @@ let
     settings = RTSettings(nx = 15, ny = 15, dx = 2.0, dy = 1.0, parallel = true)
     rtobj = RayTracer(scene, sources, settings = settings)
     nrays_traced = trace!(rtobj)
-    @test mats[1].power[1] / power_out[1] ≈ 1.0
-    @test mats[2].power[1] / power_out[1] ≈ 0.0
+    @test mats[1].power[1].value / power_out[1] ≈ 1.0
+    @test mats[2].power[1].value / power_out[1] ≈ 0.0
 
     # Simple test of having multiple materials per geometry
     r = Rectangle(length = 2.0, width = 1.0)
@@ -517,7 +517,7 @@ let
     settings = RTSettings(parallel = true)
     rtobj = RayTracer(scene, sources, settings = settings)
     nrays_traced = trace!(rtobj)
-    @test length(filter(x -> x.power[1] > 0.0, scene.materials)) == 5 # only 4 faces are seen (+ soil)
+    @test length(filter(x -> x.power[1].value > 0.0, scene.materials)) == 5 # only 4 faces are seen (+ soil)
     scene = Scene(Koch, message = "render")
     add!(scene, mesh = r, material = Black(1), color = RGB(0.5, 0.5, 0.0))
     # render(scene)
@@ -529,7 +529,7 @@ let
     settings = RTSettings(parallel = true)
     rtobj = RayTracer(scene, sources, settings = settings)
     nrays_traced = trace!(rtobj)
-    @test length(filter(x -> x.power[1] > 0.0, scene.materials)) == 17 # 8 faces seen (+ soil)
+    @test length(filter(x -> x.power[1].value > 0.0, scene.materials)) == 17 # 8 faces seen (+ soil)
     scene = Scene(Koch, message = "render")
     add!(scene, mesh = r, material = Black(1), color = RGB(0.5, 0.5, 0.0))
     # render(scene)

--- a/test/raytracer_tiles.jl
+++ b/test/raytracer_tiles.jl
@@ -1,0 +1,331 @@
+import PlantGraphs as PG
+import PlantGeomPrimitives as PGP
+import PlantGeomTurtle as PGT
+import PlantRayTracer as PRT
+import GLMakie
+#import PlantViz as PV
+using Test
+import ColorTypes: RGB
+import StaticArrays: @SVector
+
+# Simple graph that creates tiles
+module Tiles
+using PlantGraphs
+using PlantRayTracer
+struct Tile{N, M} <: Node
+    length::Float64
+    mat::Vector{Lambertian{M}}
+end
+end
+import .Tiles
+
+let
+
+    # Power and absorbed radiance are extracted with a query
+    function get_power(graph, N, M)
+        tiles = PG.apply(graph, PG.Query(Tiles.Tile{N, M}))
+        power = sum(sum(sum(pow.value for pow in mat.power) for mat in tile.mat)
+                    for tile in tiles)
+        area = length(tiles) * tiles[1].length^2
+        return power, power ./ area
+    end
+
+    # Auxilliary function for relative differences
+    rel(x, y) = abs(x - y) / x
+
+    ##################### Common elements ####################
+
+    # Length of unit tile
+    L = 1.0
+
+    # Construct the tile with N triangles
+    function PGT.feed!(turtle::PGT.Turtle, tile::Tiles.Tile{N, M}, data) where {N, M}
+        for _ in 1:N
+            PGP.Rectangle!(turtle, length = tile.length / N, width = tile.length,
+                material = tile.mat[1], color = rand(RGB), move = true)
+        end
+        return nothing
+    end
+
+    # Common settings for the ray tracer
+    settings = PRT.RTSettings(pkill = 0.3, maxiter = 3, nx = 3, ny = 3)
+    psettings = PRT.RTSettings(pkill = 0.3, maxiter = 3, nx = 3, ny = 3, parallel = true)
+
+    # Create the ray tracing scene and run it
+    function ray_trace!(scene,
+        settings,
+        acceleration = PRT.Naive;
+        radiosity = radiosity,
+        nrays = nrays)
+        source = PRT.DirectionalSource(scene,
+            θ = 0.0,
+            Φ = 0.0,
+            radiosity = radiosity,
+            nrays = nrays)
+        if acceleration == PRT.Naive
+            rtobj = PRT.RayTracer(scene,
+                source,
+                settings = settings,
+                acceleration = acceleration)
+        else
+            rtobj = PRT.RayTracer(scene,
+                source,
+                settings = settings,
+                acceleration = PRT.BVH,
+                rule = PRT.SAH{1}(2, 5))
+        end
+        nrays = PRT.trace!(rtobj)
+        return nothing
+    end
+
+    # Test results
+    function test_results(pow, irradiance, target = radiosity * 0.7, nt = 1)
+        @test rel(pow, nt * target) < 1e-2
+        @test rel(irradiance, target) < 1e-2
+        return nothing
+    end
+
+    ##################### One tile with two triangles and single wavelength ####################
+
+    # Construct the scene
+    N = 1
+    nw = 1
+    radiosity = 1.0
+    nrays = 1_000
+    axiom = PGT.RA(90.0) + Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = 0.1, ρ = 0.2)])
+    graph = PG.Graph(axiom = axiom)
+    scene = PGP.Scene(graph)
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive, radiosity = radiosity = nrays = nrays)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive, radiosity = radiosity = nrays = nrays)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH, radiosity = radiosity = nrays = nrays)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH, radiosity = radiosity = nrays = nrays)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    ##################### One tile with multiple triangles and single wavelength ####################
+    N = 10
+    nw = 1
+    radiosity = 1.0
+    nrays = 1_000
+    axiom = PGT.RA(90.0) + Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = 0.1, ρ = 0.2)])
+    graph = PG.Graph(axiom = axiom)
+    scene = PGP.Scene(graph)
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    ##################### One tile with multiple triangles and multiple wavelength ####################
+    N = 10
+    nw = 2
+    radiosity = @SVector [0.5, 0.5]
+    nrays = 1_000
+    axiom = PGT.RA(90.0) +
+            Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = (0.1, 0.1), ρ = (0.2, 0.2))])
+    graph = PG.Graph(axiom = axiom)
+    scene = PGP.Scene(graph)
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7)
+
+    ##################### Many tiles with multiple triangles and single wavelength ####################
+    N = 10
+    nw = 1
+    radiosity = 1.0
+    nrays = 1_000
+    make_tile() = Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = 0.1, ρ = 0.2)])
+    axiom = PGT.RA(90.0) + make_tile() + make_tile()
+    graph = PG.Graph(axiom = axiom)
+    scene = PGP.Scene(graph)
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    ##################### Many tiles with multiple triangles and multiple wavelengths ####################
+    N = 10
+    nw = 2
+    radiosity = @SVector [0.5, 0.5]
+    nrays = 1_000
+    make_tile() = Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = (0.1, 0.1), ρ = (0.2, 0.2))])
+    axiom = PGT.RA(90.0) + make_tile() + make_tile()
+    graph = PG.Graph(axiom = axiom)
+    scene = PGP.Scene(graph)
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH)
+    pow, irradiance = get_power(graph, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    ##################### Two graphs - many tiles with multiple triangles and multiple wavelengths ####################
+    N = 10
+    nw = 2
+    radiosity = @SVector [0.5, 0.5]
+    nrays = 500_000
+    make_tile() = Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = (0.1, 0.1), ρ = (0.2, 0.2))])
+    axiom1 = PGT.RA(90.0) + make_tile() + make_tile()
+    graph1 = PG.Graph(axiom = axiom)
+    axiom2 = PGT.RA(90.0) + PGT.F(2.0) + make_tile() + make_tile()
+    graph2 = PG.Graph(axiom = axiom2)
+    scene = PGP.Scene([graph1, graph2])
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow, irradiance = get_power(graph2, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow, irradiance = get_power(graph2, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow, irradiance = get_power(graph2, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow, irradiance = get_power(graph2, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    ##################### Two graphs - many tiles with multiple triangles and multiple wavelengths - use add! ####################
+    N = 10
+    nw = 2
+    radiosity = @SVector [0.5, 0.5]
+    nrays = 500_000
+    make_tile() = Tiles.Tile{N, nw}(L, [PRT.Lambertian(τ = (0.1, 0.1), ρ = (0.2, 0.2))])
+    axiom1 = PGT.RA(90.0) + make_tile() + make_tile()
+    graph1 = PG.Graph(axiom = axiom1)
+    axiom2 = PGT.RA(90.0) + PGT.F(2.0) + make_tile() + make_tile()
+    graph2 = PG.Graph(axiom = axiom2)
+    scene = PGP.Scene(graph1)
+    scene_extra = PGP.Scene(graph2)
+    mat = PRT.Lambertian(τ = (0.1, 0.1), ρ = (0.2, 0.2))
+    PGP.add!(scene, mesh = scene_extra.mesh, material = mat, color = rand(RGB))
+    #render_scene(scene)
+
+    # Naive + Serial
+    ray_trace!(scene, settings, PRT.Naive)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow = sum(pow.value for pow in mat.power)
+    irradiance = pow / PGP.area(scene_extra.mesh)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # Naive + Parallel
+    ray_trace!(scene, psettings, PRT.Naive)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow = sum(pow.value for pow in mat.power)
+    irradiance = pow / PGP.area(scene_extra.mesh)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Serial
+    ray_trace!(scene, settings, PRT.BVH)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow = sum(pow.value for pow in mat.power)
+    irradiance = pow / PGP.area(scene_extra.mesh)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+
+    # BVH + Parallel
+    ray_trace!(scene, psettings, PRT.BVH)
+    pow, irradiance = get_power(graph1, N, nw)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+    pow = sum(pow.value for pow in mat.power)
+    irradiance = pow / PGP.area(scene_extra.mesh)
+    test_results(pow, irradiance, sum(radiosity) * 0.7, 2)
+end

--- a/test/raytracer_tiles.jl
+++ b/test/raytracer_tiles.jl
@@ -2,7 +2,7 @@ import PlantGraphs as PG
 import PlantGeomPrimitives as PGP
 import PlantGeomTurtle as PGT
 import PlantRayTracer as PRT
-import GLMakie
+#import GLMakie
 #import PlantViz as PV
 using Test
 import ColorTypes: RGB

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,11 @@ end
     include("elements_raytracer.jl")
 end
 
+# Test ray tracing of tiles
+@testset "Ray tracing scenes" begin
+    include("raytracer_tiles.jl")
+end
+
 # Test ray tracing of scenes
 @testset "Ray tracing scenes" begin
     include("raytracer.jl")


### PR DESCRIPTION
I changed the implementation of all the materials and the ray tracer to use atomic updates of the stored power rather than the previous version that relied on copying the materials to each thread and later merging them. The original code was leading to overestimations of the absorbed power (despite using deep copies of the vector of materials). I have also added more tests since this issue was not detected. The tests now cover a wide range of situations involving the matching of triangles to materials.